### PR TITLE
Adapts Modelcheckpoint to save wandb_alias and start_time 

### DIFF
--- a/src/schnetpack/train/callbacks.py
+++ b/src/schnetpack/train/callbacks.py
@@ -87,10 +87,12 @@ class ModelCheckpoint(BaseModelCheckpoint):
     but also saves the best inference model with activated post-processing
     """
 
-    def __init__(self, model_path: str, do_postprocessing=True, *args, **kwargs):
+    def __init__(self, model_path: str, do_postprocessing=True, wandb_alias=None, start_time=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.model_path = model_path
         self.do_postprocessing = do_postprocessing
+        self.wandb_alias = wandb_alias
+        self.start_time = start_time
 
     def on_validation_end(self, trainer, pl_module: AtomisticTask) -> None:
         self.trainer = trainer


### PR DESCRIPTION
- as used in atomistic-deq-ff/src/atomistic_deq_ff/training/run.py
- belonging to /atomistic_deq_ff/ commit 557aa11c9f5f77bbed9ec32cd40f47727575591e